### PR TITLE
Last word not wrapping bug

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -545,6 +545,9 @@ const layout = (
         }
       }
       if (isLastToken) {
+        if (wordShouldWrap()) {
+          finalizeLineAndMoveCursorToNextLine();
+        }
         positionWordAtCursorAndAdvanceCursor();
         line.push(word);
         lines.push(line);


### PR DESCRIPTION
It seems that if the final word in a line falls near the end of a line, and should wrap, it doesnt.  To me it looks like simply checking if it should wrap and doing so if necessary on the last token should fix things.

Also I think this should fix the following issue:

https://github.com/mimshwright/pixi-tagged-text/issues/100