### PR TITLE
Memoize bounds

### DIFF
--- a/src/LRUCache.ts
+++ b/src/LRUCache.ts
@@ -1,6 +1,7 @@
 export interface ILRUCache<K, V> {
   get(key: K): V | undefined;
   set(key: K, value: V): void;
+  clear(): void;
 }
 
 export class LRUCache<K, V> implements ILRUCache<K, V> {
@@ -44,5 +45,9 @@ export class LRUCache<K, V> implements ILRUCache<K, V> {
       const firstKey = this.cache.keys().next().value;
       this.cache.delete(firstKey);
     }
+  }
+
+  clear(): void {
+    this.cache.clear();
   }
 }

--- a/src/LRUCache.ts
+++ b/src/LRUCache.ts
@@ -1,0 +1,48 @@
+export interface ILRUCache<K, V> {
+  get(key: K): V | undefined;
+  set(key: K, value: V): void;
+}
+
+export class LRUCache<K, V> implements ILRUCache<K, V> {
+  capacity: number;
+  cache: Map<K, V>;
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.cache = new Map();
+  }
+
+  get(key: K): V | undefined {
+    const value = this.cache.get(key);
+    // Key does not exist, return -1
+    if (value === undefined) {
+      return undefined;
+    }
+
+    // Raise to last used
+    this.cache.delete(key);
+    this.cache.set(key, value);
+
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    // If the key already exists, delete it so that it will be added
+    // to the top of the cache
+    if (this.cache.get(key)) {
+      this.cache.delete(key);
+    }
+
+    // Insert the key,value pair into cache
+    this.cache.set(key, value);
+
+    // If we've exceeded the cache capacity,
+    // then delete the least recently accessed value,
+    // which will be the item at the bottom of the cache
+    // i.e the first position
+    if (this.cache.size > this.capacity) {
+      const firstKey = this.cache.keys().next().value;
+      this.cache.delete(firstKey);
+    }
+  }
+}

--- a/src/TaggedText.ts
+++ b/src/TaggedText.ts
@@ -20,8 +20,6 @@ import {
   TextDecorationMetrics,
   isSpriteSource,
   isTextureSource,
-  IFontMetrics,
-  Bounds,
 } from "./types";
 
 import { parseTagsNew, removeTags, EMOJI_TAG } from "./tags";
@@ -122,8 +120,7 @@ export default class TaggedText extends PIXI.Sprite {
     this.setText(text);
   }
 
-  private _metricsLRUCache: ILRUCache<string, IFontMetrics>;
-  private _boundsLRUCache: ILRUCache<string, Bounds>;
+  private _boundsLRUCache: ILRUCache<string, PIXI.Rectangle> | undefined;
 
   /**
    * Setter for text that allows you to override the default for skipping the update.
@@ -347,12 +344,10 @@ export default class TaggedText extends PIXI.Sprite {
     }
 
     this.text = text;
-    this._metricsLRUCache = new LRUCache<string, IFontMetrics>(
-      this.options.cacheCapacity ?? 25
-    );
-    this._boundsLRUCache = new LRUCache<string, Bounds>(
-      this.options.cacheCapacity ?? 25
-    );
+    this._boundsLRUCache =
+      this.options.cacheCapacity != undefined && this.options.cacheCapacity > 0
+        ? new LRUCache<string, PIXI.Rectangle>(this.options.cacheCapacity)
+        : undefined;
   }
 
   public destroy(options?: boolean | PIXI.IDestroyOptions): void {
@@ -425,8 +420,7 @@ export default class TaggedText extends PIXI.Sprite {
     this._options.skipUpdates = true;
     this._options.skipDraw = true;
     this._options = {};
-    this._metricsLRUCache.clear();
-    this._boundsLRUCache.clear();
+    this._boundsLRUCache?.clear();
   }
 
   /**
@@ -577,7 +571,6 @@ export default class TaggedText extends PIXI.Sprite {
       splitStyle,
       scaleIcons,
       this.options.adjustFontBaseline,
-      this._metricsLRUCache,
       this._boundsLRUCache
     );
 

--- a/src/TaggedText.ts
+++ b/src/TaggedText.ts
@@ -21,6 +21,7 @@ import {
   isSpriteSource,
   isTextureSource,
   IFontMetrics,
+  Bounds,
 } from "./types";
 
 import { parseTagsNew, removeTags, EMOJI_TAG } from "./tags";
@@ -36,7 +37,6 @@ import { capitalize } from "./stringUtil";
 import { fontSizeStringToNumber } from "./pixiUtils";
 import { logWarning as _logWarning } from "./errorMessaging";
 import { ILRUCache, LRUCache } from "./LRUCache";
-import type { Rectangle } from "pixi.js";
 
 export const DEFAULT_OPTIONS: TaggedTextOptions = {
   debug: false,
@@ -123,7 +123,7 @@ export default class TaggedText extends PIXI.Sprite {
   }
 
   private _metricsLRUCache: ILRUCache<string, IFontMetrics>;
-  private _rectsLRUCache: ILRUCache<string, Rectangle>;
+  private _boundsLRUCache: ILRUCache<string, Bounds>;
 
   /**
    * Setter for text that allows you to override the default for skipping the update.
@@ -350,7 +350,7 @@ export default class TaggedText extends PIXI.Sprite {
     this._metricsLRUCache = new LRUCache<string, IFontMetrics>(
       this.options.cacheCapacity ?? 25
     );
-    this._rectsLRUCache = new LRUCache<string, Rectangle>(
+    this._boundsLRUCache = new LRUCache<string, Bounds>(
       this.options.cacheCapacity ?? 25
     );
   }
@@ -426,7 +426,7 @@ export default class TaggedText extends PIXI.Sprite {
     this._options.skipDraw = true;
     this._options = {};
     this._metricsLRUCache.clear();
-    this._rectsLRUCache.clear();
+    this._boundsLRUCache.clear();
   }
 
   /**
@@ -578,7 +578,7 @@ export default class TaggedText extends PIXI.Sprite {
       scaleIcons,
       this.options.adjustFontBaseline,
       this._metricsLRUCache,
-      this._rectsLRUCache
+      this._boundsLRUCache
     );
 
     this._tokens = newFinalTokens;

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -36,7 +36,6 @@ import {
   FontMap,
 } from "./types";
 import type { ILRUCache } from "./LRUCache";
-import type { Rectangle } from "pixi.js";
 
 const ICON_SCALE_BASE = 0.8;
 
@@ -615,7 +614,7 @@ export const calculateFinalTokens = (
   scaleIcons = true,
   adjustFontBaseline?: FontMap,
   metricsCache?: ILRUCache<string, IFontMetrics>,
-  rectCache?: ILRUCache<string, Rectangle>
+  boundsCache?: ILRUCache<string, Bounds>
 ): ParagraphToken => {
   // Create a text field to use for measurements.
   const defaultStyle = styledTokens.style;
@@ -683,7 +682,15 @@ export const calculateFinalTokens = (
           fontProperties.descent *= scaleHeight;
           fontProperties.fontSize *= scaleHeight;
 
-          const bounds = rectCache?.get(sizer.text) ?? rectFromContainer(sizer);
+          const boundsCached = boundsCache?.get(sizer.text);
+
+          let bounds: Bounds;
+          if (boundsCached) {
+            bounds = boundsCached;
+          } else {
+            bounds = rectFromContainer(sizer);
+            boundsCache?.set(sizer.text, bounds);
+          }
           // bounds.height = fontProperties.fontSize;
 
           // Incorporate the size of the stroke into the size of the text.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -35,7 +35,8 @@ import {
   createEmptyFinalToken,
   FontMap,
 } from "./types";
-import { ILRUCache } from "./LRUCache";
+import type { ILRUCache } from "./LRUCache";
+import type { Rectangle } from "pixi.js";
 
 const ICON_SCALE_BASE = 0.8;
 
@@ -613,7 +614,8 @@ export const calculateFinalTokens = (
   splitStyle: SplitStyle = "words",
   scaleIcons = true,
   adjustFontBaseline?: FontMap,
-  cache?: ILRUCache<string, IFontMetrics>
+  metricsCache?: ILRUCache<string, IFontMetrics>,
+  rectCache?: ILRUCache<string, Rectangle>
 ): ParagraphToken => {
   // Create a text field to use for measurements.
   const defaultStyle = styledTokens.style;
@@ -666,7 +668,7 @@ export const calculateFinalTokens = (
 
           sizer.scale.set(scaleWidth, scaleHeight);
 
-          const cacheValue = cache?.get(sizer.text);
+          const cacheValue = metricsCache?.get(sizer.text);
 
           if (cacheValue) {
             fontProperties = { ...cacheValue };
@@ -674,14 +676,14 @@ export const calculateFinalTokens = (
             fontProperties = {
               ...getFontPropertiesOfText(sizer, true),
             };
-            cache?.set(sizer.text, { ...fontProperties });
+            metricsCache?.set(sizer.text, { ...fontProperties });
           }
 
           fontProperties.ascent *= scaleHeight;
           fontProperties.descent *= scaleHeight;
           fontProperties.fontSize *= scaleHeight;
 
-          const bounds = rectFromContainer(sizer);
+          const bounds = rectCache?.get(sizer.text) ?? rectFromContainer(sizer);
           // bounds.height = fontProperties.fontSize;
 
           // Incorporate the size of the stroke into the size of the text.
@@ -727,7 +729,7 @@ export const calculateFinalTokens = (
         const imgDisplay = style[IMG_DISPLAY_PROPERTY];
         // const isBlockImage = imgDisplay === "block";
         const isIcon = imgDisplay === "icon";
-        const cacheValue = cache?.get(sizer.text);
+        const cacheValue = metricsCache?.get(sizer.text);
 
         if (cacheValue) {
           fontProperties = { ...cacheValue };
@@ -735,7 +737,7 @@ export const calculateFinalTokens = (
           fontProperties = {
             ...getFontPropertiesOfText(sizer, true),
           };
-          cache?.set(sizer.text, { ...fontProperties });
+          metricsCache?.set(sizer.text, { ...fontProperties });
         }
 
         if (isIcon) {

--- a/src/pixiUtils.ts
+++ b/src/pixiUtils.ts
@@ -5,37 +5,10 @@ const PX_PER_EM = 16;
 const PX_PER_PERCENT = 16 / 100;
 const PX_PER_PT = 1.3281472327365;
 
-export const measureFont = (context: CanvasRenderingContext2D): IFontMetrics =>
-  PIXI.TextMetrics.measureFont(context.font);
-
 export const INITIAL_FONT_PROPS: IFontMetrics = {
   ascent: 10,
   descent: 3,
   fontSize: 13,
-};
-
-// TODO: Memoize
-export const getFontPropertiesOfText = (
-  textField: PIXI.Text,
-  forceUpdate = false
-): IFontMetrics => {
-  if (forceUpdate) {
-    textField.updateText(false);
-    return measureFont(textField.context);
-  } else {
-    const props = measureFont(textField.context);
-    const fs = textField.style.fontSize ?? NaN;
-    if (
-      props.ascent === INITIAL_FONT_PROPS.ascent &&
-      props.descent === INITIAL_FONT_PROPS.descent &&
-      (isNaN(Number(fs)) || fs > INITIAL_FONT_PROPS.fontSize)
-    ) {
-      throw new Error(
-        "getFontPropertiesOfText() returned metrics associated with a Text field that has not been updated yet. Please try using the forceUpdate parameter when you call this function."
-      );
-    }
-    return measureFont(textField.context);
-  }
 };
 
 export const addChildrenToContainer = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface TaggedTextOptions {
   wrapEmoji?: boolean;
   errorHandler?: ErrorHandler;
   supressConsole?: boolean;
+  cacheCapacity?: number;
 }
 
 ///// STYLE PROPERTIES


### PR DESCRIPTION
This is an mainly an optimization of characters split style scenario, however it can be useful in other usecases also. Let me give a bit of backstory: we use pixi-tagged-text to do a text input in pixi, cause standard Text doesn't support breaking by characters. However when text is long is hurts the performance because every text segment is updated even if nothing has changed (`Text.update` in `getFontPropertiesOfText` and accessing `.width` in `rectFromContainer` are the main chokepoints). I removed `getFontPropertiesOfText` because `getFontMetrics` is internally cached in pixi (also we don't need to update text) and added cache for text bounds

I don't really like using `JSON.stringify` though